### PR TITLE
style: align the test progress status buttons

### DIFF
--- a/src/pages/test/pages/question/components/progress.tsx
+++ b/src/pages/test/pages/question/components/progress.tsx
@@ -4,8 +4,9 @@ import { Box, Button } from "../../../../../ui/controls";
 import { ButtonShape, ButtonType } from "../../../../../ui/types";
 
 const StyledDiv = styled.div`
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 50px);
+  justify-content: center;
   width: min(1920px, 100%);
   gap: 15px;
   margin-top: 30px;


### PR DESCRIPTION
Выровнены по центру окна кнопки, отражающие процесс прохождения теста на всех разрешениях. Был заменен display: flex на display: grid, так как на разных разрешениях окна просмотра flex выравнивал строку по левому краю, что приводило к образованию пустого места справа (< ширины кнопки). 