### PR TITLE
Fixed the width of the cognitive disorders block

### DIFF
--- a/src/components/details.tsx
+++ b/src/components/details.tsx
@@ -124,6 +124,10 @@ const CognitiveFunctionsGrid = styled(TwoColumnGrid)`
   }
 `;
 
+const StyledThreeColumnGrid = styled(ThreeColumnGrid)`
+  max-width: 1206px;
+`;
+
 const Details: React.FC = () => {
   return (
     <>
@@ -276,7 +280,7 @@ const Details: React.FC = () => {
       </Section>
 
       <Section flex centered mt={7}>
-        <ThreeColumnGrid>
+        <StyledThreeColumnGrid>
           <SeparatedColumn flex centered>
             <Subtitle2 uppercase={false}>Легкие</Subtitle2>
             <List>
@@ -348,7 +352,7 @@ const Details: React.FC = () => {
               </li>
             </List>
           </SeparatedColumn>
-        </ThreeColumnGrid>
+        </StyledThreeColumnGrid>
       </Section>
 
       <Section


### PR DESCRIPTION
Блок Когнитивные расстройства больше не разъезжается по ширине страницы
Было:
![image](https://user-images.githubusercontent.com/82226794/161560383-6e0a8e07-b583-4a68-8a91-05a7ad185307.png)
Стало:
![image](https://user-images.githubusercontent.com/82226794/161560339-e2c12353-8750-4811-b891-39b83b89c571.png)
