### PR TITLE
the link name in the news tab is now displayed correctly

### DIFF
--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -90,6 +90,7 @@ interface CardProps {
   cardDateTime?: string;
   cardDateTimeText: string;
   cardLinkTo: string;
+  urlLabel: string;
 }
 
 const Card: React.FC<CardProps> = ({
@@ -99,6 +100,7 @@ const Card: React.FC<CardProps> = ({
   cardDateTime,
   cardDateTimeText,
   cardLinkTo,
+  urlLabel,
 }) => {
   return (
     <StyledCard>
@@ -122,7 +124,7 @@ const Card: React.FC<CardProps> = ({
           borderBottomOnHover={false}
           to={cardLinkTo}
         >
-          <LinkButton>подробнее</LinkButton>
+          <LinkButton>{urlLabel}</LinkButton>
         </Link>
       </Box>
     </StyledCard>

--- a/src/pages/news-grid/news-grid.tsx
+++ b/src/pages/news-grid/news-grid.tsx
@@ -134,6 +134,7 @@ const NewsGridPage: React.FC = () => {
               cardDateTimeText={formattedDate || "Дата новости"}
               imageSource={article.image || cardDefImg}
               cardLinkTo={`/article/${article.id}`}
+              urlLabel={article.urlLabel || "Подробнее"}
             />
           );
         })}


### PR DESCRIPTION
<img width="1261" alt="image" src="https://user-images.githubusercontent.com/82226794/162159172-01821971-613e-43e5-b06f-61170f4d14f3.png">
