### PR TITLE
support for external links to news

### DIFF
--- a/src/pages/news-grid/news-grid.tsx
+++ b/src/pages/news-grid/news-grid.tsx
@@ -133,7 +133,7 @@ const NewsGridPage: React.FC = () => {
               cardDateTime={article.createdAt}
               cardDateTimeText={formattedDate || "Дата новости"}
               imageSource={article.image || cardDefImg}
-              cardLinkTo={article.urlLabel || `/article/${article.id}`}
+              cardLinkTo={article.url || `/article/${article.id}`}
               urlLabel={article.urlLabel || "Подробнее"}
             />
           );


### PR DESCRIPTION
Теперь, в компоненте NewsGridPage, в атрибуте cardLinkTo компонента Card передается поле urlLabel объекта article если оно не пустое, а если пустое, то передается `/article/${article.id}`